### PR TITLE
fix: added retry logic in get_icd_versions script

### DIFF
--- a/modules/icd-versions/scripts/get_icd_versions.py
+++ b/modules/icd-versions/scripts/get_icd_versions.py
@@ -3,6 +3,7 @@ import http.client
 import json
 import os
 import sys
+import time
 from urllib.parse import urlparse
 
 
@@ -56,12 +57,14 @@ def get_api_endpoint(region):
     return api_endpoint
 
 
-def fetch_icd_deployables(iam_token, api_endpoint):
+def fetch_icd_deployables(iam_token, api_endpoint, max_retries=3, retry_delay=10):
     """
-    Fetches ICD deployables versions using HTTP connection.
+    Fetches ICD deployables versions using HTTP connection with retry logic.
     Args:
         iam_token (str): IBM Cloud IAM token for authentication.
         api_endpoint (str): The API endpoint to use.
+        max_retries (int): Maximum number of retry attempts (default: 3).
+        retry_delay (int): Delay in seconds between retries (default: 10).
     Returns:
         dict: Parsed JSON response containing deployables information.
     """
@@ -77,24 +80,48 @@ def fetch_icd_deployables(iam_token, api_endpoint):
         "Accept": "application/json",
     }
 
-    conn = http.client.HTTPSConnection(host)
-    try:
-        # Final API path
-        url = "/v5/ibm/deployables"
-        conn.request("GET", url, headers=headers)
-        response = conn.getresponse()
-        data = response.read().decode()
+    last_exception = None
 
-        if response.status != 200:
-            raise RuntimeError(
-                f"API request failed: {response.status} {response.reason} - {data}"
-            )
+    for attempt in range(max_retries + 1):  # +1 to include the initial attempt
+        try:
+            conn = http.client.HTTPSConnection(host)
+            try:
+                # Final API path
+                url = "/v5/ibm/deployables"
+                conn.request("GET", url, headers=headers)
+                response = conn.getresponse()
+                data = response.read().decode()
 
-        return json.loads(data)
-    except http.client.HTTPException as e:
-        raise RuntimeError("HTTP request failed") from e
-    finally:
-        conn.close()
+                if response.status != 200:
+                    error_msg = f"API request failed: {response.status} {response.reason} - {data}"
+
+                    # If this is not the last attempt, silently retry
+                    if attempt < max_retries:
+                        time.sleep(retry_delay)
+                        continue
+                    else:
+                        raise RuntimeError(error_msg)
+
+                # Success - return the parsed JSON
+                return json.loads(data)
+
+            finally:
+                conn.close()
+
+        except (http.client.HTTPException, OSError, ConnectionError) as e:
+            last_exception = e
+
+            # If this is not the last attempt, silently retry
+            if attempt < max_retries:
+                time.sleep(retry_delay)
+            else:
+                # Last attempt failed, raise the exception
+                raise RuntimeError(
+                    f"HTTP request failed after {max_retries + 1} attempts"
+                ) from last_exception
+
+    # This should not be reached, but just in case
+    raise RuntimeError("HTTP request failed") from last_exception
 
 
 def transform_data(deployables_data, db_type):

--- a/modules/icd-versions/scripts/get_icd_versions.py
+++ b/modules/icd-versions/scripts/get_icd_versions.py
@@ -95,8 +95,11 @@ def fetch_icd_deployables(iam_token, api_endpoint, max_retries=3, retry_delay=10
                 if response.status != 200:
                     error_msg = f"API request failed: {response.status} {response.reason} - {data}"
 
-                    # If this is not the last attempt, silently retry
-                    if attempt < max_retries:
+                    # Only retry on server errors (5xx) or rate limiting (429)
+                    should_retry = response.status >= 500 or response.status == 429
+
+                    if should_retry and attempt < max_retries:
+                        conn.close()
                         time.sleep(retry_delay)
                         continue
                     else:
@@ -112,6 +115,7 @@ def fetch_icd_deployables(iam_token, api_endpoint, max_retries=3, retry_delay=10
             last_exception = e
 
             # If this is not the last attempt, silently retry
+            # we don't want to print logs for retry as they are going as input to terraform's external data block and it will break the json output expected by terraform
             if attempt < max_retries:
                 time.sleep(retry_delay)
             else:
@@ -119,9 +123,6 @@ def fetch_icd_deployables(iam_token, api_endpoint, max_retries=3, retry_delay=10
                 raise RuntimeError(
                     f"HTTP request failed after {max_retries + 1} attempts"
                 ) from last_exception
-
-    # This should not be reached, but just in case
-    raise RuntimeError("HTTP request failed") from last_exception
 
 
 def transform_data(deployables_data, db_type):


### PR DESCRIPTION
### Description

Added retry logic in API call which fetches supported versions for an ICD. This will make the script more robust for issues with ICD API's.

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
