### PR TITLE
fix: add fallback mechanism for get_icd_version script

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-09T06:39:07Z",
+  "generated_at": "2026-06-09T06:47:40Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "9d2cd1c727083671c58f3cece6768a0b0c9516e4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 29,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-05-26T14:41:15Z",
+  "generated_at": "2026-06-09T06:39:07Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "9d2cd1c727083671c58f3cece6768a0b0c9516e4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 32,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "go.sum|^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2026-06-09T06:47:40Z",
+  "generated_at": "2026-06-09T14:25:42Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -82,7 +82,7 @@
         "hashed_secret": "9d2cd1c727083671c58f3cece6768a0b0c9516e4",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 29,
+        "line_number": 27,
         "type": "Secret Keyword",
         "verified_result": null
       }

--- a/modules/icd-versions/README.md
+++ b/modules/icd-versions/README.md
@@ -10,8 +10,6 @@ This terraform module uses an external data block to call the ICD API endpoint u
 
   **Note**: Fallback is only enabled for the `ca-mon` region due to known endpoint unavailability issues. Other regions will fail immediately if their endpoint is unavailable.
 
-- **Graceful Error Handling**: The script provides detailed logging about which endpoints are being tried and which ones succeed or fail, making troubleshooting easier.
-
 ## Prerequisites
 
 ### Script Requirements

--- a/modules/icd-versions/README.md
+++ b/modules/icd-versions/README.md
@@ -4,14 +4,11 @@ This terraform module uses an external data block to call the ICD API endpoint u
 
 ## Features
 
-- **Automatic Fallback**: If the primary regional endpoint is unavailable (e.g., `api.ca-mon.databases.cloud.ibm.com`), the module automatically attempts to fetch data from fallback regions in the following priority order:
-  1. `us-south`
-  2. `ca-tor`
-  3. `us-east`
-  4. `eu-gb`
-  5. `eu-de`
-  6. `jp-tok`
-  7. `au-syd`
+- **Automatic Fallback for ca-mon Region**: Since the Montreal (`ca-mon`) regional endpoint is unavailable (e.g., `api.ca-mon.databases.cloud.ibm.com`), the module automatically attempts to fetch data from fallback regions in the following priority order:
+  1. `ca-tor` (Toronto)
+  2. `us-south` (Dallas)
+
+  **Note**: Fallback is only enabled for the `ca-mon` region due to known endpoint unavailability issues. Other regions will fail immediately if their endpoint is unavailable.
 
 - **Graceful Error Handling**: The script provides detailed logging about which endpoints are being tried and which ones succeed or fail, making troubleshooting easier.
 

--- a/modules/icd-versions/README.md
+++ b/modules/icd-versions/README.md
@@ -2,6 +2,19 @@
 
 This terraform module uses an external data block to call the ICD API endpoint using a bash script to fetch the supported versions of an ICD and outputs the list of stable versions currently supported along with latest and preferred version.
 
+## Features
+
+- **Automatic Fallback**: If the primary regional endpoint is unavailable (e.g., `api.ca-mon.databases.cloud.ibm.com`), the module automatically attempts to fetch data from fallback regions in the following priority order:
+  1. `us-south`
+  2. `ca-tor`
+  3. `us-east`
+  4. `eu-gb`
+  5. `eu-de`
+  6. `jp-tok`
+  7. `au-syd`
+
+- **Graceful Error Handling**: The script provides detailed logging about which endpoints are being tried and which ones succeed or fail, making troubleshooting easier.
+
 ## Prerequisites
 
 ### Script Requirements

--- a/modules/icd-versions/scripts/get_icd_versions.sh
+++ b/modules/icd-versions/scripts/get_icd_versions.sh
@@ -80,8 +80,8 @@ fetch_icd_deployables() {
         --show-error \
         --connect-timeout 5 \
         --max-time 10 \
-        --retry 2 \
-        --retry-delay 1 \
+        --retry 3 \
+        --retry-delay 2 \
         --retry-connrefused \
         --location \
         -w "\n%{http_code}" \
@@ -115,7 +115,6 @@ fetch_icd_deployables() {
     return 0
 }
 
-# Function to fetch deployables with fallback logic
 fetch_with_fallback() {
     local iam_token="$1"
     local primary_region="$2"
@@ -136,10 +135,8 @@ fetch_with_fallback() {
 
     # Only use fallback for ca-mon region
     if [[ "$primary_region" != "ca-mon" ]]; then
-        error "API endpoint failed for region '${primary_region}'. Fallback is only available for ca-mon region."
+        error "API endpoint failed for region '${primary_region}'."
     fi
-
-    echo "Note: Fallback mechanism activated for ca-mon region" >&2
 
     # Try fallback regions
     local fallback_regions
@@ -159,7 +156,6 @@ fetch_with_fallback() {
         echo "Warning: Fallback endpoint ${fallback_endpoint} failed" >&2
     done
 
-    # All endpoints failed
     error "All API endpoints failed. Tried primary region '${primary_region}' and fallback regions: ${fallback_regions[*]}"
 }
 

--- a/modules/icd-versions/scripts/get_icd_versions.sh
+++ b/modules/icd-versions/scripts/get_icd_versions.sh
@@ -66,7 +66,7 @@ get_fallback_regions() {
     fi
 }
 
-# Function to fetch ICD deployables with fallback support
+# Function to fetch ICD deployables
 fetch_icd_deployables() {
     local iam_token="$1"
     local api_endpoint="$2"
@@ -249,7 +249,7 @@ main() {
     local api_endpoint
     api_endpoint=$(get_api_endpoint "$region")
 
-    # Fetch deployables data with fallback support
+    # Fetch deployables data
     local deployables_data
     deployables_data=$(fetch_with_fallback "$iam_token" "$region")
 

--- a/modules/icd-versions/scripts/get_icd_versions.sh
+++ b/modules/icd-versions/scripts/get_icd_versions.sh
@@ -53,22 +53,17 @@ get_api_endpoint() {
     echo "${IBMCLOUD_ICD_API_ENDPOINT:-https://api.${region}.databases.cloud.ibm.com}"
 }
 
-# Function to get fallback regions
+# Function to get fallback regions for ca-mon
 get_fallback_regions() {
     local primary_region="$1"
 
-    # Define fallback regions in priority order
-    # Exclude the primary region from fallbacks
-    local all_fallbacks=("us-south" "ca-tor" "us-east" "eu-gb" "eu-de" "jp-tok" "au-syd")
-    local fallbacks=()
-
-    for region in "${all_fallbacks[@]}"; do
-        if [[ "$region" != "$primary_region" ]]; then
-            fallbacks+=("$region")
-        fi
-    done
-
-    echo "${fallbacks[@]}"
+    # Only ca-mon region has fallback support
+    if [[ "$primary_region" == "ca-mon" ]]; then
+        # Fallback to ca-tor first, then us-south
+        echo "ca-tor us-south"
+    else
+        echo ""
+    fi
 }
 
 # Function to fetch ICD deployables with fallback support
@@ -138,6 +133,13 @@ fetch_with_fallback() {
     fi
 
     echo "Warning: Primary endpoint ${primary_endpoint} failed or is unavailable" >&2
+
+    # Only use fallback for ca-mon region
+    if [[ "$primary_region" != "ca-mon" ]]; then
+        error "API endpoint failed for region '${primary_region}'. Fallback is only available for ca-mon region."
+    fi
+
+    echo "Note: Fallback mechanism activated for ca-mon region" >&2
 
     # Try fallback regions
     local fallback_regions

--- a/modules/icd-versions/scripts/get_icd_versions.sh
+++ b/modules/icd-versions/scripts/get_icd_versions.sh
@@ -53,7 +53,25 @@ get_api_endpoint() {
     echo "${IBMCLOUD_ICD_API_ENDPOINT:-https://api.${region}.databases.cloud.ibm.com}"
 }
 
-# Function to fetch ICD deployables
+# Function to get fallback regions
+get_fallback_regions() {
+    local primary_region="$1"
+
+    # Define fallback regions in priority order
+    # Exclude the primary region from fallbacks
+    local all_fallbacks=("us-south" "ca-tor" "us-east" "eu-gb" "eu-de" "jp-tok" "au-syd")
+    local fallbacks=()
+
+    for region in "${all_fallbacks[@]}"; do
+        if [[ "$region" != "$primary_region" ]]; then
+            fallbacks+=("$region")
+        fi
+    done
+
+    echo "${fallbacks[@]}"
+}
+
+# Function to fetch ICD deployables with fallback support
 fetch_icd_deployables() {
     local iam_token="$1"
     local api_endpoint="$2"
@@ -67,14 +85,14 @@ fetch_icd_deployables() {
         --show-error \
         --connect-timeout 5 \
         --max-time 10 \
-        --retry 3 \
-        --retry-delay 2 \
+        --retry 2 \
+        --retry-delay 1 \
         --retry-connrefused \
         --location \
         -w "\n%{http_code}" \
         -H "Authorization: Bearer ${iam_token}" \
         -H "Accept: application/json" \
-        "$url") || error "HTTP request failed"
+        "$url" 2>&1) || return 1
 
     # Split response into body and status code
     http_code="${response##*$'\n'}"
@@ -82,12 +100,12 @@ fetch_icd_deployables() {
 
     # Validate HTTP response
     if [[ "$http_code" != "200" ]]; then
-        error "API request failed with HTTP ${http_code}: ${body}"
+        return 1
     fi
 
     # Validate API response JSON
     if ! jq -e . >/dev/null 2>&1 <<< "$body"; then
-        error "Invalid JSON response from API"
+        return 1
     fi
 
     # Validate expected response structure
@@ -95,10 +113,52 @@ fetch_icd_deployables() {
         has("deployables") and
         (.deployables | type == "array")
     ' >/dev/null 2>&1 <<< "$body"; then
-        error "API response missing expected '\''deployables'\'' array"
+        return 1
     fi
 
     echo "$body"
+    return 0
+}
+
+# Function to fetch deployables with fallback logic
+fetch_with_fallback() {
+    local iam_token="$1"
+    local primary_region="$2"
+    local primary_endpoint
+    local deployables_data
+
+    primary_endpoint=$(get_api_endpoint "$primary_region")
+
+    # Try primary endpoint
+    echo "Attempting to fetch from primary endpoint: ${primary_endpoint}" >&2
+    if deployables_data=$(fetch_icd_deployables "$iam_token" "$primary_endpoint"); then
+        echo "Successfully fetched from primary endpoint: ${primary_endpoint}" >&2
+        echo "$deployables_data"
+        return 0
+    fi
+
+    echo "Warning: Primary endpoint ${primary_endpoint} failed or is unavailable" >&2
+
+    # Try fallback regions
+    local fallback_regions
+    read -ra fallback_regions <<< "$(get_fallback_regions "$primary_region")"
+
+    for fallback_region in "${fallback_regions[@]}"; do
+        local fallback_endpoint
+        fallback_endpoint=$(get_api_endpoint "$fallback_region")
+
+        echo "Attempting fallback endpoint: ${fallback_endpoint}" >&2
+        if deployables_data=$(fetch_icd_deployables "$iam_token" "$fallback_endpoint"); then
+            echo "Successfully fetched from fallback endpoint: ${fallback_endpoint}" >&2
+            echo "$deployables_data"
+            return 0
+        fi
+
+        echo "Warning: Fallback endpoint ${fallback_endpoint} failed" >&2
+    done
+
+    # All endpoints failed
+    error "All API endpoints failed. Tried primary region '${primary_region}' and fallback regions: ${fallback_regions[*]}"
 }
 
 # Function to transform data and extract versions
@@ -191,9 +251,9 @@ main() {
     local api_endpoint
     api_endpoint=$(get_api_endpoint "$region")
 
-    # Fetch deployables data
+    # Fetch deployables data with fallback support
     local deployables_data
-    deployables_data=$(fetch_icd_deployables "$iam_token" "$api_endpoint")
+    deployables_data=$(fetch_with_fallback "$iam_token" "$region")
 
     # Transform data
     local transformed


### PR DESCRIPTION
### Description

This PR adds automatic endpoint fallback for the Montreal (`ca-mon`) region in the ICD versions module. Since the primary `ca-mon` endpoint is unavailable, the module now automatically falls back to `ca-tor` and then `us-south` endpoints. 

Resolves: #157 


<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Added automatic endpoint fallback for `ca-mon` region to handle unavailable Montreal ICD API endpoint, with fallback to `ca-tor` and `us-south` regions

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
